### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ all: build
 
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machinery/make/, \
-	operator.mk \
+	golang.mk \
+	targets/openshift/images.mk \
+	targets/openshift/deps.mk \
 )
 
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:


### PR DESCRIPTION
cluster-bootstrap doesn't have generators which are part of the operator make template and get hooked into verify - which didn't work without setting up required generator args.

/cc @sttts 