### PR TITLE
Allow desc:ns/pod-prefix,ns/pod-prefix syntax for required pods

### DIFF
--- a/cmd/cluster-bootstrap/start_test.go
+++ b/cmd/cluster-bootstrap/start_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parsePodPrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		clauses  []string
+		expected map[string][]string
+		wantErr  bool
+	}{
+		{"empty", []string{}, map[string][]string{}, false},
+		{"nil", nil, map[string][]string{}, false},
+		{"no-colon", []string{"foo/bar"}, map[string][]string{"foo/bar": {"foo/bar"}}, false},
+		{"colon", []string{"desc:foo/bar"}, map[string][]string{"desc": {"foo/bar"}}, false},
+		{"no-namespace", []string{"foo"}, map[string][]string{"foo": {"foo"}}, false},
+		{"disjunction", []string{"desc:foo/bar|abc/def|ghi"}, map[string][]string{"desc": {"foo/bar", "abc/def", "ghi"}}, false},
+		{"disjunction,no-desc", []string{"foo/bar|abc/def"}, nil, true},
+		{"multiple-disjunctions", []string{"desc:foo/bar|abc/def|ghi", "desc2:jkl/mno"}, map[string][]string{"desc": {"foo/bar", "abc/def", "ghi"}, "desc2": {"jkl/mno"}}, false},
+		{"mixed", []string{"desc:foo/bar", "abc/def"}, map[string][]string{"desc": {"foo/bar"}, "abc/def": {"abc/def"}}, false},
+		{"split-disjunctions", []string{"desc:foo/bar|abc/def|ghi", "desc:jkl/mno"}, map[string][]string{"desc": {"foo/bar", "abc/def", "ghi", "jkl/mno"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePodPrefixes(tt.clauses)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePodPrefixes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("parsePodPrefixes() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -24,7 +24,7 @@ type Config struct {
 	AssetDir             string
 	PodManifestPath      string
 	Strict               bool
-	RequiredPods         []string
+	RequiredPodPrefixes  map[string][]string
 	WaitForTearDownEvent string
 }
 
@@ -32,7 +32,7 @@ type startCommand struct {
 	podManifestPath      string
 	assetDir             string
 	strict               bool
-	requiredPods         []string
+	requiredPodPrefixes  map[string][]string
 	waitForTearDownEvent string
 }
 
@@ -41,7 +41,7 @@ func NewStartCommand(config Config) (*startCommand, error) {
 		assetDir:             config.AssetDir,
 		podManifestPath:      config.PodManifestPath,
 		strict:               config.Strict,
-		requiredPods:         config.RequiredPods,
+		requiredPodPrefixes:  config.RequiredPodPrefixes,
 		waitForTearDownEvent: config.WaitForTearDownEvent,
 	}, nil
 }
@@ -80,7 +80,7 @@ func (b *startCommand) Run() error {
 		return err
 	}
 
-	if err = waitUntilPodsRunning(client, b.requiredPods, bootstrapPodsRunningTimeout); err != nil {
+	if err = waitUntilPodsRunning(client, b.requiredPodPrefixes, bootstrapPodsRunningTimeout); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is necessary during pod renames, to accept different pod name prefixes during the transition.