### PR TITLE
pkg/start: Prune public API

### DIFF
--- a/pkg/start/asset.go
+++ b/pkg/start/asset.go
@@ -1,12 +1,12 @@
 package start
 
 const (
-	AssetPathSecrets            = "tls"
-	AssetPathAdminKubeConfig    = "auth/kubeconfig"
-	AssetPathManifests          = "manifests"
-	AssetPathBootstrapManifests = "bootstrap-manifests"
+	assetPathSecrets            = "tls"
+	assetPathAdminKubeConfig    = "auth/kubeconfig"
+	assetPathManifests          = "manifests"
+	assetPathBootstrapManifests = "bootstrap-manifests"
 )
 
 var (
-	BootstrapSecretsDir = "/etc/kubernetes/bootstrap-secrets" // Overridden for testing.
+	bootstrapSecretsDir = "/etc/kubernetes/bootstrap-secrets" // Overridden for testing.
 )

--- a/pkg/start/bootstrap_test.go
+++ b/pkg/start/bootstrap_test.go
@@ -24,31 +24,31 @@ func setUp(t *testing.T) (assetDir, podManifestPath string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	BootstrapSecretsDir, err = ioutil.TempDir("", "bootstrap-secrets")
+	bootstrapSecretsDir, err = ioutil.TempDir("", "bootstrap-secrets")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Create assets.
-	if err := os.Mkdir(filepath.Join(assetDir, filepath.Dir(AssetPathAdminKubeConfig)), os.FileMode(0755)); err != nil {
+	if err := os.Mkdir(filepath.Join(assetDir, filepath.Dir(assetPathAdminKubeConfig)), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(assetDir, AssetPathAdminKubeConfig), []byte("kubeconfig data"), os.FileMode(0644)); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(assetDir, assetPathAdminKubeConfig), []byte("kubeconfig data"), os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(assetDir, AssetPathSecrets), os.FileMode(0755)); err != nil {
+	if err := os.Mkdir(filepath.Join(assetDir, assetPathSecrets), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	for _, secret := range secrets {
-		if err := ioutil.WriteFile(filepath.Join(assetDir, AssetPathSecrets, secret), []byte("secret data"), os.FileMode(0644)); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(assetDir, assetPathSecrets, secret), []byte("secret data"), os.FileMode(0644)); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.Mkdir(filepath.Join(assetDir, AssetPathBootstrapManifests), os.FileMode(0755)); err != nil {
+	if err := os.Mkdir(filepath.Join(assetDir, assetPathBootstrapManifests), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	for _, manifest := range manifests {
-		if err := ioutil.WriteFile(filepath.Join(assetDir, AssetPathBootstrapManifests, manifest), []byte("manifest data"), os.FileMode(0644)); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(assetDir, assetPathBootstrapManifests, manifest), []byte("manifest data"), os.FileMode(0644)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -62,7 +62,7 @@ func tearDown(assetDir, podManifestPath string, t *testing.T) {
 	if err := os.RemoveAll(podManifestPath); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.RemoveAll(BootstrapSecretsDir); err != nil {
+	if err := os.RemoveAll(bootstrapSecretsDir); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -72,14 +72,14 @@ func TestBootstrapControlPlane(t *testing.T) {
 	defer tearDown(assetDir, podManifestPath, t)
 
 	// Create and start bootstrap control plane.
-	bcp := NewBootstrapControlPlane(assetDir, podManifestPath)
+	bcp := newBootstrapControlPlane(assetDir, podManifestPath)
 	if err := bcp.Start(); err != nil {
 		t.Errorf("bcp.Start() = %v, want: nil", err)
 	}
 
 	// Make sure assets were copied.
 	for _, secret := range secrets {
-		if _, err := os.Stat(filepath.Join(BootstrapSecretsDir, secret)); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(bootstrapSecretsDir, secret)); os.IsNotExist(err) {
 			t.Errorf("bcp.Start() failed to copy secret: %v", secret)
 		}
 	}
@@ -95,7 +95,7 @@ func TestBootstrapControlPlane(t *testing.T) {
 	}
 
 	// Make sure directories were properly cleaned up.
-	if fi, err := os.Stat(BootstrapSecretsDir); fi != nil || !os.IsNotExist(err) {
+	if fi, err := os.Stat(bootstrapSecretsDir); fi != nil || !os.IsNotExist(err) {
 		t.Error("bcp.Teardown() failed to delete secrets directory")
 	}
 	for _, manifest := range manifests {
@@ -117,14 +117,14 @@ func TestBootstrapControlPlaneNoOverwrite(t *testing.T) {
 	}
 
 	// Create and start bootstrap control plane.
-	bcp := NewBootstrapControlPlane(assetDir, podManifestPath)
+	bcp := newBootstrapControlPlane(assetDir, podManifestPath)
 	if err := bcp.Start(); err == nil {
 		t.Errorf("bcp.Start() = %v, want: non-nil", err)
 	}
 
 	// Make sure assets were copied.
 	for _, secret := range secrets {
-		if _, err := os.Stat(filepath.Join(BootstrapSecretsDir, secret)); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(bootstrapSecretsDir, secret)); os.IsNotExist(err) {
 			t.Errorf("bcp.Start() failed to copy secret: %v", secret)
 		}
 	}
@@ -149,7 +149,7 @@ func TestBootstrapControlPlaneNoOverwrite(t *testing.T) {
 	}
 
 	// Make sure directories were properly cleaned up.
-	if fi, err := os.Stat(BootstrapSecretsDir); fi != nil || !os.IsNotExist(err) {
+	if fi, err := os.Stat(bootstrapSecretsDir); fi != nil || !os.IsNotExist(err) {
 		t.Error("bcp.Teardown() failed to delete secrets directory")
 	}
 	for _, manifest := range manifests {

--- a/pkg/start/create.go
+++ b/pkg/start/create.go
@@ -34,7 +34,7 @@ const (
 	crdRolloutTimeout  = 2 * time.Minute
 )
 
-func CreateAssets(config clientcmd.ClientConfig, manifestDir string, timeout time.Duration, strict bool) error {
+func createAssets(config clientcmd.ClientConfig, manifestDir string, timeout time.Duration, strict bool) error {
 	if _, err := os.Stat(manifestDir); os.IsNotExist(err) {
 		UserOutput(fmt.Sprintf("WARNING: %v does not exist, not creating any self-hosted assets.\n", manifestDir))
 		return nil

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -37,10 +37,10 @@ func (b *startCommand) Run() error {
 	// TODO(diegs): create and share a single client rather than the kubeconfig once all uses of it
 	// are migrated to client-go.
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(b.assetDir, AssetPathAdminKubeConfig)},
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(b.assetDir, assetPathAdminKubeConfig)},
 		&clientcmd.ConfigOverrides{})
 
-	bcp := NewBootstrapControlPlane(b.assetDir, b.podManifestPath)
+	bcp := newBootstrapControlPlane(b.assetDir, b.podManifestPath)
 
 	defer func() {
 		// Always tear down the bootstrap control plane and clean up manifests and secrets.
@@ -61,11 +61,11 @@ func (b *startCommand) Run() error {
 		return err
 	}
 
-	if err = CreateAssets(kubeConfig, filepath.Join(b.assetDir, AssetPathManifests), assetTimeout, b.strict); err != nil {
+	if err = createAssets(kubeConfig, filepath.Join(b.assetDir, assetPathManifests), assetTimeout, b.strict); err != nil {
 		return err
 	}
 
-	if err = WaitUntilPodsRunning(kubeConfig, b.requiredPods, assetTimeout); err != nil {
+	if err = waitUntilPodsRunning(kubeConfig, b.requiredPods, assetTimeout); err != nil {
 		return err
 	}
 

--- a/pkg/start/status.go
+++ b/pkg/start/status.go
@@ -17,8 +17,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func WaitUntilPodsRunning(c clientcmd.ClientConfig, pods []string, timeout time.Duration) error {
-	sc, err := NewStatusController(c, pods)
+func waitUntilPodsRunning(c clientcmd.ClientConfig, pods []string, timeout time.Duration) error {
+	sc, err := newStatusController(c, pods)
 	if err != nil {
 		return err
 	}
@@ -36,10 +36,10 @@ type statusController struct {
 	client        kubernetes.Interface
 	podStore      cache.Store
 	watchPods     []string
-	lastPodPhases map[string]*PodStatus
+	lastPodPhases map[string]*podStatus
 }
 
-func NewStatusController(c clientcmd.ClientConfig, pods []string) (*statusController, error) {
+func newStatusController(c clientcmd.ClientConfig, pods []string) (*statusController, error) {
 	config, err := c.ClientConfig()
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (s *statusController) Run() {
 }
 
 func (s *statusController) AllRunningAndReady() (bool, error) {
-	ps, err := s.PodStatus()
+	ps, err := s.podStatus()
 	if err != nil {
 		glog.Infof("Error retriving pod statuses: %v", err)
 		return false, nil
@@ -113,16 +113,16 @@ func (s *statusController) AllRunningAndReady() (bool, error) {
 	return runningAndReady, nil
 }
 
-// PodStatus describes a pod's phase and readiness.
-type PodStatus struct {
+// podStatus describes a pod's phase and readiness.
+type podStatus struct {
 	Phase   v1.PodPhase
 	IsReady bool
 }
 
-// PodStatus retrieves the pod status by reading the PodPhase and whether it is ready.
+// podStatus retrieves the pod status by reading the PodPhase and whether it is ready.
 // A non existing pod is represented with nil.
-func (s *statusController) PodStatus() (map[string]*PodStatus, error) {
-	status := make(map[string]*PodStatus)
+func (s *statusController) podStatus() (map[string]*podStatus, error) {
+	status := make(map[string]*podStatus)
 
 	podNames := s.podStore.ListKeys()
 	for _, watchedPod := range s.watchPods {
@@ -142,7 +142,7 @@ func (s *statusController) PodStatus() (map[string]*PodStatus, error) {
 			continue
 		}
 		if p, ok := p.(*v1.Pod); ok {
-			status[watchedPod] = &PodStatus{
+			status[watchedPod] = &podStatus{
 				Phase: p.Status.Phase,
 			}
 			for _, c := range p.Status.Conditions {


### PR DESCRIPTION
Lowercase labels that are not used outside of this package to make it easier to discover the intended public API for the package.  After this pull-request:

```console
$ godoc ./pkg/start/
PACKAGE DOCUMENTATION

package start
    import "./pkg/start/"

FUNCTIONS

func NewStartCommand(config Config) (*startCommand, error)

func UserOutput(format string, a ...interface{})
    All start command printing to stdout should go through this fmt.Printf
    wrapper. The stdout of the start command should convey information
    useful to a human sitting at a terminal watching their cluster bootstrap
    itself. Otherwise the message should go to stderr.

TYPES

type Config struct {
    AssetDir        string
    PodManifestPath string
    Strict          bool
    RequiredPods    []string
}
```