### PR TITLE
Copy static pod logs to systemd via --send-static-pod-logs-to-systemd

### DIFF
--- a/cmd/cluster-bootstrap/start.go
+++ b/cmd/cluster-bootstrap/start.go
@@ -21,11 +21,12 @@ var (
 	}
 
 	startOpts struct {
-		assetDir             string
-		podManifestPath      string
-		strict               bool
-		requiredPods         []string
-		waitForTearDownEvent string
+		assetDir                   string
+		podManifestPath            string
+		strict                     bool
+		requiredPods               []string
+		waitForTearDownEvent       string
+		sendStaticPodLogsToSystemD bool
 	}
 )
 
@@ -43,15 +44,17 @@ func init() {
 	cmdStart.Flags().BoolVar(&startOpts.strict, "strict", false, "Strict mode will cause start command to exit early if any manifests in the asset directory cannot be created.")
 	cmdStart.Flags().StringSliceVar(&startOpts.requiredPods, "required-pods", defaultRequiredPods, "List of pods with their namespace (written as <namespace>/<pod-name>) that are required to be running and ready before the start command does the pivot.")
 	cmdStart.Flags().StringVar(&startOpts.waitForTearDownEvent, "tear-down-event", "", "if this optional event name of the form <ns>/<event-name> is given, the event is waited for before tearing down the bootstrap control plane")
+	cmdStart.Flags().BoolVar(&startOpts.sendStaticPodLogsToSystemD, "--send-static-pod-logs-to-systemd", false, "Send cri-o logs of static pods to the equaly named systemd units before tear down for later scraping.")
 }
 
 func runCmdStart(cmd *cobra.Command, args []string) error {
 	bk, err := start.NewStartCommand(start.Config{
-		AssetDir:             startOpts.assetDir,
-		PodManifestPath:      startOpts.podManifestPath,
-		Strict:               startOpts.strict,
-		RequiredPods:         startOpts.requiredPods,
-		WaitForTearDownEvent: startOpts.waitForTearDownEvent,
+		AssetDir:                   startOpts.assetDir,
+		PodManifestPath:            startOpts.podManifestPath,
+		Strict:                     startOpts.strict,
+		RequiredPods:               startOpts.requiredPods,
+		WaitForTearDownEvent:       startOpts.waitForTearDownEvent,
+		SendStaticPodLogsToSystemD: startOpts.sendStaticPodLogsToSystemD,
 	})
 	if err != nil {
 		return err

--- a/cmd/cluster-bootstrap/start.go
+++ b/cmd/cluster-bootstrap/start.go
@@ -21,10 +21,11 @@ var (
 	}
 
 	startOpts struct {
-		assetDir        string
-		podManifestPath string
-		strict          bool
-		requiredPods    []string
+		assetDir             string
+		podManifestPath      string
+		strict               bool
+		requiredPods         []string
+		waitForTearDownEvent string
 	}
 )
 
@@ -41,14 +42,16 @@ func init() {
 	cmdStart.Flags().StringVar(&startOpts.podManifestPath, "pod-manifest-path", "/etc/kubernetes/manifests", "The location where the kubelet is configured to look for static pod manifests.")
 	cmdStart.Flags().BoolVar(&startOpts.strict, "strict", false, "Strict mode will cause start command to exit early if any manifests in the asset directory cannot be created.")
 	cmdStart.Flags().StringSliceVar(&startOpts.requiredPods, "required-pods", defaultRequiredPods, "List of pods with their namespace (written as <namespace>/<pod-name>) that are required to be running and ready before the start command does the pivot.")
+	cmdStart.Flags().StringVar(&startOpts.waitForTearDownEvent, "tear-down-event", "", "if this optional event name of the form <ns>/<event-name> is given, the event is waited for before tearing down the bootstrap control plane")
 }
 
 func runCmdStart(cmd *cobra.Command, args []string) error {
 	bk, err := start.NewStartCommand(start.Config{
-		AssetDir:        startOpts.assetDir,
-		PodManifestPath: startOpts.podManifestPath,
-		Strict:          startOpts.strict,
-		RequiredPods:    startOpts.requiredPods,
+		AssetDir:             startOpts.assetDir,
+		PodManifestPath:      startOpts.podManifestPath,
+		Strict:               startOpts.strict,
+		RequiredPods:         startOpts.requiredPods,
+		WaitForTearDownEvent: startOpts.waitForTearDownEvent,
 	})
 	if err != nil {
 		return err

--- a/cmd/cluster-bootstrap/start.go
+++ b/cmd/cluster-bootstrap/start.go
@@ -57,12 +57,7 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = bk.Run()
-	if err != nil {
-		// Always report errors.
-		start.UserOutput("Error: %v\n", err)
-	}
-	return err
+	return bk.Run()
 }
 
 func validateStartOpts(cmd *cobra.Command, args []string) error {

--- a/pkg/start/status.go
+++ b/pkg/start/status.go
@@ -14,10 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
-func waitUntilPodsRunning(c clientcmd.ClientConfig, pods []string, timeout time.Duration) error {
+func waitUntilPodsRunning(c kubernetes.Interface, pods []string, timeout time.Duration) error {
 	sc, err := newStatusController(c, pods)
 	if err != nil {
 		return err
@@ -39,15 +38,7 @@ type statusController struct {
 	lastPodPhases map[string]*podStatus
 }
 
-func newStatusController(c clientcmd.ClientConfig, pods []string) (*statusController, error) {
-	config, err := c.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
+func newStatusController(client kubernetes.Interface, pods []string) (*statusController, error) {
 	return &statusController{client: client, watchPods: pods}, nil
 }
 


### PR DESCRIPTION
We want to get static pod logs when the installer fails for some reason. We already scrape bootkube, cri-o and kubelet. This change will "copy" the cri-o container logs to systemd unit via `systemd-run --unit <pod-name> crictl logs <container-id>`. After that we can scrape it from the CI job through journald.

Follow-up of https://github.com/openshift/release/pull/2633.