### PR TITLE
Add test-e2e target to silence CI messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,5 @@ $(call build-image,origin-$(GO_PACKAGE),./Dockerfile,.)
 clean:
 	$(RM) ./cluster-bootstrap
 .PHONY: clean
+
+test-e2e: # there is none right now


### PR DESCRIPTION
We are seeing `make: *** No rule to make target `test-e2e'.  Stop.` in CI tests, e.g. https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-bootstrap/10/pull-ci-openshift-cluster-bootstrap-master-e2e-aws-operator/56/build-log.txt
