### PR TITLE
pkg/start/asset: Add support for post-pod-manifests

### DIFF
--- a/pkg/start/asset.go
+++ b/pkg/start/asset.go
@@ -4,6 +4,7 @@ const (
 	assetPathSecrets            = "tls"
 	assetPathAdminKubeConfig    = "auth/kubeconfig"
 	assetPathManifests          = "manifests"
+	assetPathPostPodManifests   = "post-pod-manifests"
 	assetPathBootstrapManifests = "bootstrap-manifests"
 )
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -84,6 +84,10 @@ func (b *startCommand) Run() error {
 		return err
 	}
 
+	if err = createAssets(restConfig, filepath.Join(b.assetDir, assetPathPostPodManifests), bootstrapPodsRunningTimeout, b.strict); err != nil {
+		return err
+	}
+
 	// notify installer that we are ready to tear down the temporary bootstrap control plane
 	UserOutput("Sending bootstrap-success event.")
 	if _, err := client.CoreV1().Events("kube-system").Create(makeBootstrapSuccessEvent("kube-system", "bootstrap-success")); err != nil && !apierrors.IsAlreadyExists(err) {

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -76,7 +76,7 @@ func (b *startCommand) Run() error {
 		return err
 	}
 
-	if err = createAssets(restConfig, filepath.Join(b.assetDir, assetPathManifests), bootstrapPodsRunningTimeout, b.strict); err != nil {
+	if err = createAssets(restConfig, filepath.Join(b.assetDir, assetPathManifests), bootstrapPodsRunningTimeout, b.strict, 0); err != nil {
 		return err
 	}
 
@@ -84,7 +84,7 @@ func (b *startCommand) Run() error {
 		return err
 	}
 
-	if err = createAssets(restConfig, filepath.Join(b.assetDir, assetPathPostPodManifests), bootstrapPodsRunningTimeout, b.strict); err != nil {
+	if err = createAssets(restConfig, filepath.Join(b.assetDir, assetPathPostPodManifests), bootstrapPodsRunningTimeout, b.strict, 10*time.Second); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
So the installer can inject objects that require OpenShift custom resources (e.g. machine(set)s).  We currently do this [in a separate script][1] that happens before `bootstrap-complete`, but it's a good fit for cluster-bootstrap, which already has object-injection logic for the pre-pod assets.

CC @sttts

[1]: https://github.com/openshift/installer/blob/v0.11.0/data/data/bootstrap/files/usr/local/bin/openshift.sh