### PR TITLE
WIP: scrape all bootstrap container logs to systemd

### DIFF
--- a/pkg/start/bootstrap_test.go
+++ b/pkg/start/bootstrap_test.go
@@ -90,7 +90,8 @@ func TestBootstrapControlPlane(t *testing.T) {
 	}
 
 	// Tear down control plane.
-	if err := bcp.Teardown(); err != nil {
+	bcp.Teardown()
+	if err := bcp.TeardownError(); err != nil && len(bcp.teardownErrors) > 1 {
 		t.Errorf("bcp.Teardown() = %v, want: nil", err)
 	}
 
@@ -144,7 +145,10 @@ func TestBootstrapControlPlaneNoOverwrite(t *testing.T) {
 	}
 
 	// Tear down control plane.
-	if err := bcp.Teardown(); err != nil {
+	bcp.Teardown()
+
+	// tolerate lstat /var/log/pods: no such file or directory
+	if err := bcp.TeardownError(); err != nil && len(bcp.teardownErrors) > 1 {
 		t.Errorf("bcp.Start() = %v, want: nil", err)
 	}
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -61,9 +61,10 @@ func (b *startCommand) Run() error {
 	bcp := newBootstrapControlPlane(b.assetDir, b.podManifestPath)
 
 	defer func() {
-		// Always tear down the bootstrap control plane and clean up manifests and secrets.
-		if err := bcp.Teardown(); err != nil {
-			UserOutput("Error tearing down temporary bootstrap control plane: %v\n", err)
+		// Teardown will remove all manifests and secrets in addition to preserving all bootstrap container logs
+		bcp.Teardown()
+		if err := bcp.TeardownError(); err != nil {
+			UserOutput("Tearing down temporary bootstrap control plane failed with following errors:\n%v\n", err)
 		}
 	}()
 


### PR DESCRIPTION
This change will at the end of the bootstrap, but before we remove the manifests walk trough `/var/logs/pod` directory and copy every log file for each container into systemd via `systemd-run`.