### PR TITLE
start: tear down bootstrap control plane as early as possible

### DIFF
--- a/pkg/start/bootstrap.go
+++ b/pkg/start/bootstrap.go
@@ -48,6 +48,10 @@ func (b *bootstrapControlPlane) Start() error {
 // Teardown brings down the bootstrap control plane and cleans up the temporary manifests and
 // secrets. This function is idempotent.
 func (b *bootstrapControlPlane) Teardown() error {
+	if b == nil {
+		return nil
+	}
+
 	UserOutput("Tearing down temporary bootstrap control plane...\n")
 	if err := os.RemoveAll(bootstrapSecretsDir); err != nil {
 		return err

--- a/pkg/start/status.go
+++ b/pkg/start/status.go
@@ -1,6 +1,7 @@
 package start
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -16,14 +17,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func waitUntilPodsRunning(c kubernetes.Interface, pods map[string][]string, timeout time.Duration) error {
+func waitUntilPodsRunning(ctx context.Context, c kubernetes.Interface, pods map[string][]string) error {
 	sc, err := newStatusController(c, pods)
 	if err != nil {
 		return err
 	}
 	sc.Run()
 
-	if err := wait.Poll(5*time.Second, timeout, sc.AllRunningAndReady); err != nil {
+	if err := wait.PollImmediateUntil(5*time.Second, sc.AllRunningAndReady, ctx.Done()); err != nil {
 		return fmt.Errorf("error while checking pod status: %v", err)
 	}
 


### PR DESCRIPTION
Some operators have to wait for the bootstrap control plane to be shut down, e.g. before rolling out new certs. With this PR we shut down the bootstrap control plane as soon as possible to not block those operators too long. We then switch over to using the ELB to contact the apiserver (before tear down we speak to localhost).