### PR TITLE
minor typos on error messages

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -114,7 +114,7 @@ func (b *startCommand) Run() error {
 				select {
 				case <-ctx.Done():
 				default:
-					UserOutput("Assert creation failed: %v\n", err)
+					UserOutput("Asset creation failed: %v\n", err)
 					cancel()
 				}
 			}

--- a/vendor/github.com/openshift/library-go/pkg/assets/create/creater.go
+++ b/vendor/github.com/openshift/library-go/pkg/assets/create/creater.go
@@ -238,7 +238,7 @@ func load(assetsDir string, options CreateOptions) (map[string]*unstructured.Uns
 		}
 		manifestUnstructured, ok := manifestObj.(*unstructured.Unstructured)
 		if !ok {
-			errs[manifestPath] = fmt.Errorf("unable to convert asset %q to unstructed", manifestPath)
+			errs[manifestPath] = fmt.Errorf("unable to convert asset %q to unstructured", manifestPath)
 			continue
 		}
 		manifests[manifestPath] = manifestUnstructured


### PR DESCRIPTION
A few minor error message typos when debugging cluster-bootstrap logs.