### PR TITLE
pkg/start: use loopback kubeconfig to talk to API

### DIFF
--- a/pkg/start/asset.go
+++ b/pkg/start/asset.go
@@ -2,7 +2,7 @@ package start
 
 const (
 	assetPathSecrets            = "tls"
-	assetPathAdminKubeConfig    = "auth/kubeconfig"
+	assetPathAdminKubeConfig    = "auth/kubeconfig-loopback"
 	assetPathManifests          = "manifests"
 	assetPathBootstrapManifests = "bootstrap-manifests"
 )


### PR DESCRIPTION
This code modifies cluster-bootstrap to use a kubeconfig configured for localhost API access.

This is necessary due to a limitation with Azure internal load balancers. See limitation #2 here: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview#limitations

"Unlike public Load Balancers which provide outbound connections when transitioning from private IP addresses inside the virtual network to public IP addresses, internal Load Balancers do not translate outbound originated connections to the frontend of an internal Load Balancer as both are in private IP address space. This avoids potential for SNAT port exhaustion inside unique internal IP address space where translation is not required. The side effect is that if an outbound flow from a VM in the backend pool attempts a flow to frontend of the internal Load Balancer in which pool it resides and is mapped back to itself, both legs of the flow don't match and the flow will fail."

kubeconfig-loopback is generated by the installer. 

https://jira.coreos.com/browse/CORS-1094