### PR TITLE
bug 1802802: Send bootstrap-finished event when all assets are created

### DIFF
--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -174,6 +174,11 @@ func (b *startCommand) Run() error {
 	UserOutput("Waiting for remaining assets to be created.\n")
 	assetsDone.Wait()
 
+	UserOutput("Sending bootstrap-finished event.")
+	if _, err := client.CoreV1().Events("kube-system").Create(makeBootstrapSuccessEvent("kube-system", "bootstrap-finished")); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This can be used by etcd operator to know when the bootstrap control plane does not need the bootstrap etcd anymore.