### PR TITLE
Override existing static pod manifest in case it already exist

### DIFF
--- a/pkg/start/bootstrap.go
+++ b/pkg/start/bootstrap.go
@@ -40,7 +40,7 @@ func (b *bootstrapControlPlane) Start() error {
 
 	// Copy the static manifests to the kubelet's pod manifest path.
 	manifestsDir := filepath.Join(b.assetDir, assetPathBootstrapManifests)
-	ownedManifests, err := copyDirectory(manifestsDir, b.podManifestPath, false /* overwrite */)
+	ownedManifests, err := copyDirectory(manifestsDir, b.podManifestPath, true /* overwrite */)
 	b.ownedManifests = ownedManifests // always copy in case of partial failure.
 	return err
 }


### PR DESCRIPTION
This change help the cluster bootsrap recover in case a static pod manifest already exist