### PR TITLE
Revert "manifests/image-references: add kube-etcd-signer-server"

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,9 +6,3 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-cluster-bootstrap:v4.0
-# The `kube-etcd-signer-server` image is required on the bootstrap node to sign certificates
-# for the etcd members to allow bootstrapping of the etcd cluster.      
-  - name: kube-etcd-signer-server
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:kube-etcd-signer-server


### PR DESCRIPTION
Reverts openshift/cluster-bootstrap#22

Since we no longer use `kube-etcd-signer-server`[1] dropping the ref in manifests.

[1] https://github.com/openshift/cluster-etcd-operator/pull/412

cc @sttts 