### PR TITLE
Bug 1951639: Add --tear-down-delay and --tear-down-termination-timeout

### DIFF
--- a/cmd/cluster-bootstrap/start.go
+++ b/cmd/cluster-bootstrap/start.go
@@ -27,6 +27,7 @@ var (
 		requiredPodClauses   []string
 		waitForTearDownEvent string
 		earlyTearDown        bool
+		terminationTimeout   time.Duration
 		tearDownDelay        time.Duration
 		assetsCreatedTimeout time.Duration
 	}
@@ -47,6 +48,7 @@ func init() {
 	cmdStart.Flags().StringSliceVar(&startOpts.requiredPodClauses, "required-pods", defaultRequiredPods, "List of pods name prefixes with their namespace (written as <namespace>/<pod-prefix>) that are required to be running and ready before the start command does the pivot, or alternatively a list of or'ed pod prefixes with a description (written as <desc>:<namespace>/<pod-prefix>|<namespace>/<pod-prefix>|...).")
 	cmdStart.Flags().StringVar(&startOpts.waitForTearDownEvent, "tear-down-event", "", "if this optional event name of the form <ns>/<event-name> is given, the event is waited for before tearing down the bootstrap control plane")
 	cmdStart.Flags().BoolVar(&startOpts.earlyTearDown, "tear-down-early", true, "tear down immediately after the non-bootstrap control plane is up and bootstrap-success event is created.")
+	cmdStart.Flags().DurationVar(&startOpts.terminationTimeout, "tear-down-termination-timeout", 0, "wait of (graceful) termination of the bootstrap control-plane before reporting success. Set to zero to disable.")
 	cmdStart.Flags().DurationVar(&startOpts.tearDownDelay, "tear-down-delay", 0, "duration to delay the bootstrap control-plane tear-down before bootstrap-success event is created, in order to give load-balancers time to observe the self-hosted control-plane. This even applies in case of --tear-down-early.")
 	cmdStart.Flags().DurationVar(&startOpts.assetsCreatedTimeout, "assets-create-timeout", time.Duration(60)*time.Minute, "how long to wait for all the assets be created.")
 }
@@ -64,6 +66,7 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		RequiredPodPrefixes:  podPrefixes,
 		WaitForTearDownEvent: startOpts.waitForTearDownEvent,
 		EarlyTearDown:        startOpts.earlyTearDown,
+		TerminationTimeout:   startOpts.terminationTimeout,
 		TearDownDelay:        startOpts.tearDownDelay,
 		AssetsCreatedTimeout: startOpts.assetsCreatedTimeout,
 	})

--- a/cmd/cluster-bootstrap/start.go
+++ b/cmd/cluster-bootstrap/start.go
@@ -27,6 +27,7 @@ var (
 		requiredPodClauses   []string
 		waitForTearDownEvent string
 		earlyTearDown        bool
+		tearDownDelay        time.Duration
 		assetsCreatedTimeout time.Duration
 	}
 )
@@ -45,7 +46,8 @@ func init() {
 	cmdStart.Flags().BoolVar(&startOpts.strict, "strict", false, "Strict mode will cause start command to exit early if any manifests in the asset directory cannot be created.")
 	cmdStart.Flags().StringSliceVar(&startOpts.requiredPodClauses, "required-pods", defaultRequiredPods, "List of pods name prefixes with their namespace (written as <namespace>/<pod-prefix>) that are required to be running and ready before the start command does the pivot, or alternatively a list of or'ed pod prefixes with a description (written as <desc>:<namespace>/<pod-prefix>|<namespace>/<pod-prefix>|...).")
 	cmdStart.Flags().StringVar(&startOpts.waitForTearDownEvent, "tear-down-event", "", "if this optional event name of the form <ns>/<event-name> is given, the event is waited for before tearing down the bootstrap control plane")
-	cmdStart.Flags().BoolVar(&startOpts.earlyTearDown, "tear-down-early", true, "tear down immediate after the non-bootstrap control plane is up and bootstrap-success event is created.")
+	cmdStart.Flags().BoolVar(&startOpts.earlyTearDown, "tear-down-early", true, "tear down immediately after the non-bootstrap control plane is up and bootstrap-success event is created.")
+	cmdStart.Flags().DurationVar(&startOpts.tearDownDelay, "tear-down-delay", 0, "duration to delay the bootstrap control-plane tear-down before bootstrap-success event is created, in order to give load-balancers time to observe the self-hosted control-plane. This even applies in case of --tear-down-early.")
 	cmdStart.Flags().DurationVar(&startOpts.assetsCreatedTimeout, "assets-create-timeout", time.Duration(60)*time.Minute, "how long to wait for all the assets be created.")
 }
 
@@ -62,6 +64,7 @@ func runCmdStart(cmd *cobra.Command, args []string) error {
 		RequiredPodPrefixes:  podPrefixes,
 		WaitForTearDownEvent: startOpts.waitForTearDownEvent,
 		EarlyTearDown:        startOpts.earlyTearDown,
+		TearDownDelay:        startOpts.tearDownDelay,
 		AssetsCreatedTimeout: startOpts.assetsCreatedTimeout,
 	})
 	if err != nil {

--- a/pkg/start/bootstrap_test.go
+++ b/pkg/start/bootstrap_test.go
@@ -109,7 +109,7 @@ func TestBootstrapControlPlane(t *testing.T) {
 	}
 
 	// Tear down control plane.
-	if err := bcp.Teardown(); err != nil {
+	if err := bcp.Teardown(0); err != nil {
 		t.Errorf("bcp.Teardown() = %v, want: nil", err)
 	}
 
@@ -163,7 +163,7 @@ func TestBootstrapControlPlaneNoOverwrite(t *testing.T) {
 	}
 
 	// Tear down control plane.
-	if err := bcp.Teardown(); err != nil {
+	if err := bcp.Teardown(0); err != nil {
 		t.Errorf("bcp.Start() = %v, want: nil", err)
 	}
 

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -33,6 +33,7 @@ type Config struct {
 	RequiredPodPrefixes  map[string][]string
 	WaitForTearDownEvent string
 	EarlyTearDown        bool
+	TerminationTimeout   time.Duration
 	TearDownDelay        time.Duration
 	AssetsCreatedTimeout time.Duration
 }
@@ -44,6 +45,7 @@ type startCommand struct {
 	requiredPodPrefixes  map[string][]string
 	waitForTearDownEvent string
 	earlyTearDown        bool
+	terminationTimeout   time.Duration
 	tearDownDelay        time.Duration
 	assetsCreatedTimeout time.Duration
 }
@@ -56,6 +58,7 @@ func NewStartCommand(config Config) (*startCommand, error) {
 		requiredPodPrefixes:  config.RequiredPodPrefixes,
 		waitForTearDownEvent: config.WaitForTearDownEvent,
 		earlyTearDown:        config.EarlyTearDown,
+		terminationTimeout:   config.TerminationTimeout,
 		tearDownDelay:        config.TearDownDelay,
 		assetsCreatedTimeout: config.AssetsCreatedTimeout,
 	}, nil
@@ -80,7 +83,7 @@ func (b *startCommand) Run() error {
 
 	// Always tear down the bootstrap control plane and clean up manifests and secrets.
 	defer func() {
-		if err := bcp.Teardown(); err != nil {
+		if err := bcp.Teardown(b.terminationTimeout); err != nil {
 			UserOutput("Error tearing down temporary bootstrap control plane: %v\n", err)
 		}
 	}()
@@ -170,9 +173,9 @@ func (b *startCommand) Run() error {
 		UserOutput("Got %s event.", b.waitForTearDownEvent)
 	}
 
-	// tear down the bootstrap control plane. Set bcp to nil to avoid a second tear down in the defer func.
+	// tear down the bootstrap control plane early. Set bcp to nil to avoid a second tear down in the defer func.
 	if b.earlyTearDown {
-		err = bcp.Teardown()
+		err = bcp.Teardown(b.terminationTimeout)
 		bcp = nil
 		if err != nil {
 			UserOutput("Error tearing down temporary bootstrap control plane: %v\n", err)
@@ -182,6 +185,15 @@ func (b *startCommand) Run() error {
 	// wait for the tail of assets to be created after tear down
 	UserOutput("Waiting for remaining assets to be created.\n")
 	assetsDone.Wait()
+
+	// tear down the bootstrap control plane late after asset creation. Set bcp to nil to avoid a second tear down in the defer func.
+	if !b.earlyTearDown {
+		err = bcp.Teardown(b.terminationTimeout)
+		bcp = nil
+		if err != nil {
+			UserOutput("Error tearing down temporary bootstrap control plane: %v\n", err)
+		}
+	}
 
 	// We want to fail in case we failed to create some manifests
 	if ctx.Err() == context.DeadlineExceeded {


### PR DESCRIPTION
This is the first half to add a tear-down delay to give LBs time to observe the self-hosted control-plane. The other half will be in installer adding the delay flag.

- `--tear-down-delay` to give LBs time to observe the self-hosted control-plane
- `--tear-down-termination-timeout` to wait for the graceful termination of the bootstrap control-plane in order to give LBs time to observe that the bootstrap apiserver is gone.