### PR TITLE
Bug 1953563: Add .ci-operator.yaml with build_root_image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.14


### PR DESCRIPTION
Using golang 1.14 as in openshift/release.

Prereq for https://github.com/openshift/cluster-bootstrap/pull/59 and https://github.com/openshift/release/pull/18022.