### PR TITLE
OCPBUGS-34034: Updating ose-cluster-bootstrap-container image to be consistent with ART for 4.17

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-bootstrap
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-bootstrap
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.Version=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-bootstrap
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-bootstrap/cluster-bootstrap /
 ENTRYPOINT ["/cluster-bootstrap"]
 COPY manifests /manifests


### PR DESCRIPTION
Updating ose-cluster-bootstrap-container image to be consistent with ART for 4.17. There is a go version error fo origin PR https://github.com/openshift/cluster-bootstrap/pull/104 was created by [openshift-bot](https://github.com/openshift-bot), have to create new one manually and closing the PR https://github.com/openshift/cluster-bootstrap/pull/104.