### PR TITLE
Target typo ha_checker.go

### DIFF
--- a/pkg/start/ha_checker.go
+++ b/pkg/start/ha_checker.go
@@ -109,7 +109,7 @@ func newAPIAvailabilityPoller(loopbackOperatorClient operatorversionedclient.Int
 			available := 0
 			msg := ""
 			for _, status := range statuses {
-				msg = fmt.Sprintf("%s [%s at Current: %d, Traget: %d]", msg, status.NodeName, status.CurrentRevision, status.TargetRevision)
+				msg = fmt.Sprintf("%s [%s at Current: %d, Target: %d]", msg, status.NodeName, status.CurrentRevision, status.TargetRevision)
 				if status.CurrentRevision >= 1 {
 					available++
 				}
@@ -139,7 +139,7 @@ func newSchedulerAvailabilityPoller(loopbackOperatorClient operatorversionedclie
 			available := 0
 			msg := ""
 			for _, status := range statuses {
-				msg = fmt.Sprintf("%s [%s at Current: %d, Traget: %d]", msg, status.NodeName, status.CurrentRevision, status.TargetRevision)
+				msg = fmt.Sprintf("%s [%s at Current: %d, Target: %d]", msg, status.NodeName, status.CurrentRevision, status.TargetRevision)
 				if status.CurrentRevision >= 1 {
 					available++
 				}
@@ -169,7 +169,7 @@ func newKCMAvailabilityPoller(loopbackOperatorClient operatorversionedclient.Int
 			available := 0
 			msg := ""
 			for _, status := range statuses {
-				msg = fmt.Sprintf("%s [%s at Current: %d, Traget: %d]", msg, status.NodeName, status.CurrentRevision, status.TargetRevision)
+				msg = fmt.Sprintf("%s [%s at Current: %d, Target: %d]", msg, status.NodeName, status.CurrentRevision, status.TargetRevision)
 				if status.CurrentRevision >= 1 {
 					available++
 				}


### PR DESCRIPTION
There is a typo in `target` keyword. Correct typing helps when parsing the logs for troubleshooting.