### PR TITLE
CNF-23048: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/bootstrapinplace/bootstrapinplace.go
+++ b/pkg/bootstrapinplace/bootstrapinplace.go
@@ -4,7 +4,7 @@ package bootstrapinplace
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/coreos/butane/config"
@@ -44,7 +44,7 @@ func (i *BootstrapInPlaceCommand) Create() error {
 	}
 	defer infile.Close()
 
-	dataIn, err := ioutil.ReadAll(infile)
+	dataIn, err := io.ReadAll(infile)
 	if err != nil {
 		fail("Error occurred while trying to read %s: %v\n", infile.Name(), err)
 	}

--- a/pkg/start/asset.go
+++ b/pkg/start/asset.go
@@ -2,8 +2,9 @@ package start
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/openshift/installer/pkg/types"
-	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -21,7 +22,7 @@ var (
 )
 
 func getInstallConfig(file string) (*types.InstallConfig, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/start/bootstrap_test.go
+++ b/pkg/start/bootstrap_test.go
@@ -2,7 +2,6 @@ package start
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -32,15 +31,15 @@ func createTestServer() (*httptest.Server, string) {
 func setUp(t *testing.T) (assetDir, podManifestPath string) {
 	// Create source directories.
 	var err error
-	assetDir, err = ioutil.TempDir("", "assets")
+	assetDir, err = os.MkdirTemp("", "assets")
 	if err != nil {
 		t.Fatal(err)
 	}
-	podManifestPath, err = ioutil.TempDir("", "manifests")
+	podManifestPath, err = os.MkdirTemp("", "manifests")
 	if err != nil {
 		t.Fatal(err)
 	}
-	bootstrapSecretsDir, err = ioutil.TempDir("", "bootstrap-secrets")
+	bootstrapSecretsDir, err = os.MkdirTemp("", "bootstrap-secrets")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,14 +48,14 @@ func setUp(t *testing.T) (assetDir, podManifestPath string) {
 	if err := os.Mkdir(filepath.Join(assetDir, filepath.Dir(assetPathAdminKubeConfig)), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(assetDir, assetPathAdminKubeConfig), []byte("kubeconfig data"), os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(assetDir, assetPathAdminKubeConfig), []byte("kubeconfig data"), os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Mkdir(filepath.Join(assetDir, assetPathSecrets), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 	for _, secret := range secrets {
-		if err := ioutil.WriteFile(filepath.Join(assetDir, assetPathSecrets, secret), []byte("secret data"), os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(filepath.Join(assetDir, assetPathSecrets, secret), []byte("secret data"), os.FileMode(0644)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -64,7 +63,7 @@ func setUp(t *testing.T) (assetDir, podManifestPath string) {
 		t.Fatal(err)
 	}
 	for _, manifest := range manifests {
-		if err := ioutil.WriteFile(filepath.Join(assetDir, assetPathBootstrapManifests, manifest), []byte("manifest data"), os.FileMode(0644)); err != nil {
+		if err := os.WriteFile(filepath.Join(assetDir, assetPathBootstrapManifests, manifest), []byte("manifest data"), os.FileMode(0644)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -131,7 +130,7 @@ func TestBootstrapControlPlaneNoOverwrite(t *testing.T) {
 	existingData := []byte("existing data")
 
 	// Create a manifest in the destination already.
-	if err := ioutil.WriteFile(filepath.Join(podManifestPath, existingManifest), existingData, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(podManifestPath, existingManifest), existingData, os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -152,7 +151,7 @@ func TestBootstrapControlPlaneNoOverwrite(t *testing.T) {
 			t.Errorf("bcp.Start() failed to copy manifest: %v", manifest)
 		}
 		if manifest == existingManifest {
-			data, err := ioutil.ReadFile(filepath.Join(podManifestPath, manifest))
+			data, err := os.ReadFile(filepath.Join(podManifestPath, manifest))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Migration from `ioutil` to `os`/`io` functions:**

* Replaced `ioutil.ReadAll` with `io.ReadAll` in `pkg/bootstrapinplace/bootstrapinplace.go`. [[1]](diffhunk://#diff-0c6a96147b238b94dbadacda3e1b5aff5473fffe24e0b929731d0aff9a8f6d22L7-R7) [[2]](diffhunk://#diff-0c6a96147b238b94dbadacda3e1b5aff5473fffe24e0b929731d0aff9a8f6d22L47-R47)
* Replaced `ioutil.ReadFile` with `os.ReadFile` in `pkg/start/asset.go` and `pkg/start/bootstrap_test.go`. [[1]](diffhunk://#diff-d6cbe92e21d9c0b6dd4d1706847a861d63a280b2cb5e26a775ac7ff78d483f97L24-R25) [[2]](diffhunk://#diff-547d7f62ad345a3f086bc82edf09c2302a3750db3d7f1309ddf8efd389a159edL155-R154)
* Replaced `ioutil.TempDir` with `os.MkdirTemp` in `pkg/start/bootstrap_test.go`.
* Replaced `ioutil.WriteFile` with `os.WriteFile` in `pkg/start/bootstrap_test.go`. [[1]](diffhunk://#diff-547d7f62ad345a3f086bc82edf09c2302a3750db3d7f1309ddf8efd389a159edL52-R66) [[2]](diffhunk://#diff-547d7f62ad345a3f086bc82edf09c2302a3750db3d7f1309ddf8efd389a159edL134-R133)
* Removed unused `ioutil` imports from affected files. [[1]](diffhunk://#diff-d6cbe92e21d9c0b6dd4d1706847a861d63a280b2cb5e26a775ac7ff78d483f97R5-L6) [[2]](diffhunk://#diff-547d7f62ad345a3f086bc82edf09c2302a3750db3d7f1309ddf8efd389a159edL5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced deprecated utility functions with modern equivalents across the codebase.
  * Updated test helpers and internal file-handling to use current platform APIs.
  * Removed obsolete imports and made small related housekeeping changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->