### PR TITLE
NO-JIRA: OWNERS: remove engineers who have left Red Hat

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,18 +2,12 @@ approvers:
 - benluddy
 - deads2k
 - dgrisonnet
-- dinhxuanvu
-- mfojtik
 - sanchezl
-- sttts
-- tkashem
 
 reviewers:
 - benluddy
 - dgrisonnet
-- dinhxuanvu
 - sanchezl
-- tkashem
 
 # This is a Red Hat extension, mapping the Git repository to an OpenShift Bugzilla component:
 # https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform


### PR DESCRIPTION
## Summary
- Remove engineers who are no longer with Red Hat from OWNERS file

### Removed
- sttts (Stefan Schimanski)
- mfojtik (Michal Fojtik)
- tkashem (Abu H Kashem)
- dinhxuanvu (Vu Dinh)